### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Python linting
+permissions:
+  contents: read
 
 on: 
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/chuanseng-ng/bouldering-analysis/security/code-scanning/1](https://github.com/chuanseng-ng/bouldering-analysis/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly define the permissions required for the workflow. Since the workflow only needs to read repository contents (e.g., for checking out the code and installing dependencies), we will set `contents: read`. This ensures the workflow does not have unnecessary write permissions.

The changes will be made to the `.github/workflows/pylint.yml` file by adding the `permissions` key at the top level, right after the `name` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
